### PR TITLE
Fixed checking of input file type

### DIFF
--- a/www/frontend.js
+++ b/www/frontend.js
@@ -87,8 +87,20 @@ const handleDrop = (e, textArea) => {
 
     const dt = e.dataTransfer;
     const files = dt.files;
-    if (files.length !== 1) alert('You have to insert exactly 1 file.');
+    if (files.length !== 1) {
+        alert('You have to insert exactly 1 file.');
+        return;
+    }
     const file = files[0];
+    const extension = file.name.split('.').pop();
+    if (extension !== 'txt') {
+        alert('The file has to be a .txt file.');
+        return;
+    }
+    if (file.type !== 'text/plain') {
+        alert('The file has to be a text file.');
+        return;
+    }
 
     file.text()
         .then(text => {


### PR DESCRIPTION
This fixes issue #4. Now an alert is given if the user inputs multiple
files, the file doesn't have the .txt extension or is not a text file.